### PR TITLE
Add attribute to change position of indicators (top|bottom)

### DIFF
--- a/viewpager/IndicatorViewPager.js
+++ b/viewpager/IndicatorViewPager.js
@@ -14,24 +14,39 @@ export default class IndicatorViewPager extends Component {
     static propTypes = {
         ...ViewPager.propTypes,
         indicator: PropTypes.node,
+        indicatorPosition: PropTypes.string,
         pagerStyle: View.propTypes.style
     };
     static defaultProps = {
         indicator: null,
+    indicatorPosition: 'bottom',
         initialPage: 0
     };
 
     render() {
+
+        const container = (
+            <ViewPager
+                {...this.props}
+                key="ivp-container"
+                ref={VIEWPAGER_REF}
+                style={[styles.pager, this.props.pagerStyle]}
+                onPageScroll={this._onPageScroll.bind(this)}
+                onPageSelected={this._onPageSelected.bind(this)}
+            />
+        );
+
+        const indicator = (
+            <View key="ivp-indicator">
+                {this._renderIndicator()}
+            </View>
+        );
+
+        const orderedViews = this.props.indicatorPosition == 'top' ? [indicator, container] : [container, indicator];
+
         return (
             <View style={[styles.container, this.props.style]}>
-                <ViewPager
-                    {...this.props}
-                    ref={VIEWPAGER_REF}
-                    style={[styles.pager, this.props.pagerStyle]}
-                    onPageScroll={this._onPageScroll.bind(this)}
-                    onPageSelected={this._onPageSelected.bind(this)}
-                />
-                {this._renderIndicator()}
+                {orderedViews}
             </View>
         );
     }


### PR DESCRIPTION
Example of usage: 

``` js

<IndicatorViewPager
    indicatorPosition="top"
    style={{flex:1,marginTop:10}}
    indicator={this._renderTitleIndicator()}>
    <View style={{backgroundColor:'cadetblue'}}>
        <Text>page one</Text>
    </View>
    <View style={{backgroundColor:'cornflowerblue'}}>
        <Text>page two</Text>
    </View>
    <View style={{backgroundColor:'#1AA094'}}>
        <Text>page three</Text>
    </View>
</IndicatorViewPager>

```
