### PR TITLE
Add `forceScrollView` prop to force useing ScrollView on Android

### DIFF
--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -4,8 +4,8 @@
 
 'use strict'
 
+import { PanResponder, Platform, ScrollView, StyleSheet, View, ViewPagerAndroid } from 'react-native'
 import React, { Component } from 'react'
-import { StyleSheet, View, ViewPagerAndroid, ScrollView, Platform, PanResponder } from 'react-native'
 
 const SCROLLVIEW_REF = 'scrollView'
 const VIEWPAGER_REF = 'viewPager'
@@ -57,8 +57,7 @@ export default class ViewPager extends Component {
     }
 
     render () {
-        if (this.props.forceScrollView) { return this._renderOnIOS(); }
-        return Platform.OS === 'ios' ? this._renderOnIOS() : (
+        return (this.props.forceScrollView || Platform.OS === 'ios') ? this._renderOnIOS() : (
             <ViewPagerAndroid
                 {...this.props}
                 ref={VIEWPAGER_REF}
@@ -159,7 +158,7 @@ export default class ViewPager extends Component {
     }
 
     setPageWithoutAnimation (selectedPage) {
-        if (Platform.OS === 'ios')
+        if (this.props.forceScrollView || Platform.OS === 'ios')
             this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage, animated: false})
         else {
             this.refs[VIEWPAGER_REF].setPageWithoutAnimation(selectedPage)
@@ -168,7 +167,7 @@ export default class ViewPager extends Component {
     }
 
     setPage (selectedPage) {
-        if (Platform.OS === 'ios') this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage})
+        if (this.props.forceScrollView || Platform.OS === 'ios') this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage})
         else {
             this.refs[VIEWPAGER_REF].setPage(selectedPage)
             if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})

--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -57,6 +57,7 @@ export default class ViewPager extends Component {
     }
 
     render () {
+        if (this.props.forceScrollView) { return this._renderOnIOS(); }
         return Platform.OS === 'ios' ? this._renderOnIOS() : (
             <ViewPagerAndroid
                 {...this.props}


### PR DESCRIPTION
`ViewPagerAndroid` is having problem displaying pages when used with `react-navigation`.

Added the `forceScrollView` prop to force using `ScrollView` on Android.