### PR TITLE
Props for disabling horizontal scroll

### DIFF
--- a/docs/indicatorviewpager.md
+++ b/docs/indicatorviewpager.md
@@ -6,5 +6,6 @@
 | pagerStyle | View.propTypes.style |  |  |
 | autoPlayEnable | bool | false |  |
 | autoPlayInterval | number | 3000  |  |
+| horizontalScroll | bool | true  |  |
 
 

--- a/docs/tabindicator.md
+++ b/docs/tabindicator.md
@@ -10,5 +10,6 @@
 | selectedIconStyle | Image.propTypes.style |  |  |
 | textStyle | Text.propTypes.style |  |  |
 | selectedTextStyle | Text.propTypes.style |  |  |
+| changePageWithAnimation | PropTypes.bool | true |  |
 
 

--- a/viewpager/IndicatorViewPager.js
+++ b/viewpager/IndicatorViewPager.js
@@ -16,14 +16,16 @@ export default class IndicatorViewPager extends Component {
         indicator: PropTypes.node,
         pagerStyle: View.propTypes.style,
         autoPlayEnable: PropTypes.bool,
-        autoPlayInterval: PropTypes.number
+        autoPlayInterval: PropTypes.number,
+        horizontalScroll: PropTypes.bool
     }
 
     static defaultProps = {
         indicator: null,
         initialPage: 0,
         autoPlayInterval: 3000,
-        autoPlayEnable: false
+        autoPlayEnable: false,
+        horizontalScroll: true
     }
 
     constructor (props) {
@@ -57,6 +59,7 @@ export default class IndicatorViewPager extends Component {
             <View style={[styles.container, this.props.style]} >
                 <ViewPager
                     {...this.props}
+                    horizontalScroll={this.props.horizontalScroll}
                     ref={VIEWPAGER_REF}
                     style={[styles.pager, this.props.pagerStyle]}
                     onPageScroll={this._onPageScroll}

--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -60,6 +60,7 @@ export default class ViewPager extends Component {
         return (this.props.forceScrollView || Platform.OS === 'ios') ? this._renderOnIOS() : (
             <ViewPagerAndroid
                 {...this.props}
+                scrollEnabled={this.props.horizontalScroll ? true : false}
                 ref={VIEWPAGER_REF}
                 onPageScroll={this._onPageScrollOnAndroid}
                 onPageSelected={this._onPageSelectedOnAndroid}
@@ -85,7 +86,7 @@ export default class ViewPager extends Component {
             ref: SCROLLVIEW_REF,
             onLayout: this._onScrollViewLayout,
             horizontal: true,
-            pagingEnabled: true,
+            pagingEnabled: this.props.horizontalScroll ? true : false,
             scrollsToTop: false,
             showsHorizontalScrollIndicator: false,
             showsVerticalScrollIndicator: false,

--- a/viewpager/indicator/PagerTabIndicator.js
+++ b/viewpager/indicator/PagerTabIndicator.js
@@ -22,11 +22,13 @@ export default class PagerTabIndicator extends Component {
         iconStyle: Image.propTypes.style,
         selectedIconStyle: Image.propTypes.style,
         textStyle: Text.propTypes.style,
-        selectedTextStyle: Text.propTypes.style
+        selectedTextStyle: Text.propTypes.style,
+        changePageWithAnimation: PropTypes.bool,
     }
 
     static defaultProps = {
-        tabs: []
+        tabs: [],
+        changePageWithAnimation: true
     }
 
     state = {
@@ -36,7 +38,7 @@ export default class PagerTabIndicator extends Component {
     render () {
         let {
             tabs, pager, style, itemStyle, selectedItemStyle, iconStyle,
-            selectedIconStyle, textStyle, selectedTextStyle
+            selectedIconStyle, textStyle, selectedTextStyle, changePageWithAnimation
         } = this.props
         if (!tabs || tabs.length === 0) return null
 
@@ -47,7 +49,13 @@ export default class PagerTabIndicator extends Component {
                     style={[styles.itemContainer, isSelected ? selectedItemStyle : itemStyle]}
                     activeOpacity={0.6}
                     key={index}
-                    onPress={() => {!isSelected && pager.setPage(index)}}
+                    onPress={() => {
+                        if (!isSelected){
+                            if (this.props.changePageWithAnimation)
+                                pager.setPageWithoutAnimation(index);
+                            else pager.setPage(index);
+                        }
+                    }}
                 >
                     <Image
                         style={[styles.image, isSelected ? selectedIconStyle : iconStyle]}


### PR DESCRIPTION
This pull request contains props which can disable horizontal scrolling. This might be needed, especially in combination with PagerTabIndicator, when the developer wants to follow the materialdesgin style guide (see https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-style and scroll a bit down; swiping views with the main tab bar is declared as a DONT).

This pull request introduces two props:

horizontalScroll on IndicatorViewPager: enable or disable horizontal scroll (default true)

changePageWithAnimation on PagerTabIndicator: enable or disable animation when changing pages (default true).

