### PR TITLE
fix: PagerTitleIndicator少量item无法通过itemStyle来控制，铺满屏幕

### DIFF
--- a/RNViewPagerDemo/app/pages/TitleIndicatorPage.js
+++ b/RNViewPagerDemo/app/pages/TitleIndicatorPage.js
@@ -4,11 +4,11 @@
 
 'use strict'
 import React, { Component } from 'react'
-import { StyleSheet, View, Text, Platform, Image, TouchableOpacity, Animated } from 'react-native'
+import { StyleSheet, View, Text, Platform, Image, TouchableOpacity, Animated,Dimensions } from 'react-native'
 import { SquarePagerView, TrianglePagerView, CirclePagerView } from '../components/PagerItemView'
-import { IndicatorViewPager } from 'rn-viewpager'
-import PagerTitleIndicator from '../../viewpager/indicator/PagerTitleIndicator';
+import { IndicatorViewPager,PagerTitleIndicator } from 'rn-viewpager'
 
+const windowWidth = Dimensions.get('window').width;
 export default class TitleIndicatorPage extends Component {
     state = {
         bgColor: new Animated.Value(0)
@@ -57,9 +57,11 @@ export default class TitleIndicatorPage extends Component {
                 style={styles.indicatorContainer}
                 trackScroll={true}
                 itemTextStyle={styles.indicatorText}
+                itemStyle={{width:windowWidth/4}}
+                selectedItemStyle={{width:windowWidth/4}}
                 selectedItemTextStyle={styles.indicatorSelectedText}
                 selectedBorderStyle={styles.selectedBorderStyle}
-                titles={['SQUARE', 'CIRCLE', 'TRIANGLE','SQUARE', 'CIRCLE', 'TRIANGLE','SQUARE', 'CIRCLE', 'TRIANGLE']}
+                titles={['SQUARE', 'CIRCLE','TRIANGLE','SQUARE', 'CIRCLE','TRIANGLE','SQUARE', 'CIRCLE','TRIANGLE']}
             />
         )
     }

--- a/viewpager/indicator/PagerTitleIndicator.js
+++ b/viewpager/indicator/PagerTitleIndicator.js
@@ -70,10 +70,13 @@ export default class PagerTitleIndicator extends Component {
             let isSelected = this.state.selectedIndex === index
 
             const itemMargin = (itemStyle && itemStyle.marginLeft) || DEFAULT_ITEM_MARGIN;
-            const itemMarginObj =
-                index < this._titleCount - 1
-                ? { marginLeft: itemMargin }
-                : { marginLeft: itemMargin, marginRight: itemMargin };
+            let itemMarginObj = null;
+            if (!itemStyle && !selectedItemStyle) {
+                itemMarginObj =
+                    index < this._titleCount - 1
+                    ? { marginLeft: itemMargin }
+                    : { marginLeft: itemMargin, marginRight: itemMargin };
+            }
 
             const titleView = this.props.renderTitle ? this.props.renderTitle(index, title, isSelected) : (
                 <Text style={isSelected ? [styles.titleTextSelected, selectedItemTextStyle] : [styles.titleText, itemTextStyle]} >
@@ -123,6 +126,8 @@ export default class PagerTitleIndicator extends Component {
     }
 
     _visibleDetect(selectedIndex) {
+        if(selectedIndex > this._titleCount -1 ) return ;
+
         const curItemLayoutInfo = itemLayoutInfo[selectedIndex];
         const { width, x: curItemOffsetX } = curItemLayoutInfo.layout;
         const curItemAbsPosition = width + curItemOffsetX + DEFAULT_ITEM_MARGIN; // add on margin


### PR DESCRIPTION
[相关讨论](https://github.com/zbtang/React-Native-ViewPager/issues/95)