### PR TITLE
解决ViewPager的禁用滚动设置无效的问题

### DIFF
--- a/docs/viewpager.md
+++ b/docs/viewpager.md
@@ -8,7 +8,7 @@
 | onPageScroll | function |  |  |
 | onPageScrollStateChanged | function |  |  |
 | onPageSelected | function |  |  |
-| scrollEnabled | bool | false |  |
+| horizontalScroll | bool | true |  |
 
 
 | Method | Params | Default | Note |

--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -18,166 +18,164 @@ const SCROLL_STATE = {
 export default class ViewPager extends Component {
     static propTypes = {...ViewPagerAndroid.propTypes}
 
-    static defaultProps = {
-        initialPage: 0,
-        keyboardDismissMode: 'on-drag',
-        onPageScroll: null,
-        onPageSelected: null,
-        onPageScrollStateChanged: null,
-        pageMargin: 0,
-        horizontalScroll: true
-    }
+static defaultProps = {
+    initialPage: 0,
+    keyboardDismissMode: 'on-drag',
+    onPageScroll: null,
+    onPageSelected: null,
+    onPageScrollStateChanged: null,
+    pageMargin: 0,
+    horizontalScroll: true
+}
 
+state = {width: 0, height: 0}
 
-    _scrollState = SCROLL_STATE.idle
+_scrollState = SCROLL_STATE.idle
 
-    _preScrollX = null
+_preScrollX = null
 
-    _panResponder = PanResponder.create({
-        onStartShouldSetPanResponder: () => true,
-        onMoveShouldSetPanResponder: () => true,
-        onPanResponderGrant: () => this._setScrollState(SCROLL_STATE.dragging),
-        onPanResponderMove: () => null,
-        onPanResponderRelease: () => this._setScrollState(SCROLL_STATE.settling),
-        onPanResponderTerminate: () => null,
-        onPanResponderTerminationRequest: (evt, gestureState) => true
-    })
+_panResponder = PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onMoveShouldSetPanResponder: () => true,
+    onPanResponderGrant: () => this._setScrollState(SCROLL_STATE.dragging),
+    onPanResponderMove: () => null,
+    onPanResponderRelease: () => this._setScrollState(SCROLL_STATE.settling),
+    onPanResponderTerminate: () => null,
+    onPanResponderTerminationRequest: (evt, gestureState) => true
+})
 
-    constructor (props) {
-        super(props)
-        this._onPageScrollOnAndroid = this._onPageScrollOnAndroid.bind(this)
-        this._onPageSelectedOnAndroid = this._onPageSelectedOnAndroid.bind(this)
-        this._renderOnIOS = this._renderOnIOS.bind(this)
-        this._onScrollOnIOS = this._onScrollOnIOS.bind(this)
-        this._onScrollViewLayout = this._onScrollViewLayout.bind(this)
-        this._childrenWithOverridenStyle = this._childrenWithOverridenStyle.bind(this)
-        this._setScrollState = this._setScrollState.bind(this)
-        this.setPageWithoutAnimation = this.setPageWithoutAnimation.bind(this)
-        this.setPage = this.setPage.bind(this)
-        this.state = {width: 0, height: 0, page: props.initialPage}
-    }
+constructor (props) {
+    super(props)
+    this._onPageScrollOnAndroid = this._onPageScrollOnAndroid.bind(this)
+    this._onPageSelectedOnAndroid = this._onPageSelectedOnAndroid.bind(this)
+    this._renderOnIOS = this._renderOnIOS.bind(this)
+    this._onScrollOnIOS = this._onScrollOnIOS.bind(this)
+    this._onScrollViewLayout = this._onScrollViewLayout.bind(this)
+    this._childrenWithOverridenStyle = this._childrenWithOverridenStyle.bind(this)
+    this._setScrollState = this._setScrollState.bind(this)
+    this.setPageWithoutAnimation = this.setPageWithoutAnimation.bind(this)
+    this.setPage = this.setPage.bind(this)
+}
 
-    render () {
-        return (this.props.forceScrollView || Platform.OS === 'ios') ? this._renderOnIOS() : (
-            <ViewPagerAndroid
-                {...this.props}
-                scrollEnabled={this.props.horizontalScroll ? true : false}
-                ref={VIEWPAGER_REF}
-                key={this.props.children ? this.props.children.length : 0}
-                onPageScroll={this._onPageScrollOnAndroid}
-                onPageSelected={this._onPageSelectedOnAndroid}
-            />
-        )
-    }
+render () {
+    return (this.props.forceScrollView || Platform.OS === 'ios') ? this._renderOnIOS() : (
+        <ViewPagerAndroid
+    {...this.props}
+    scrollEnabled={this.props.horizontalScroll ? true : false}
+    ref={VIEWPAGER_REF}
+    key={this.props.children ? this.props.children.length : 0}
+    onPageScroll={this._onPageScrollOnAndroid}
+    onPageSelected={this._onPageSelectedOnAndroid}
+    />
+)
+}
 
-    _onPageScrollOnAndroid (e) {
-        if (this.props.onPageScroll) this.props.onPageScroll(e.nativeEvent)
-    }
+_onPageScrollOnAndroid (e) {
+    if (this.props.onPageScroll) this.props.onPageScroll(e.nativeEvent)
+}
 
-    _onPageSelectedOnAndroid (e) {
-        if (this.props.onPageSelected) this.props.onPageSelected(e.nativeEvent)
-    }
+_onPageSelectedOnAndroid (e) {
+    if (this.props.onPageSelected) this.props.onPageSelected(e.nativeEvent)
+}
 
-    _renderOnIOS () {
-        let childrenCount = this.props.children ? this.props.children.length : 0
-        let initialPage = Math.min(Math.max(0, this.props.initialPage), childrenCount - 1)
-        let needMonitorScroll = !!this.props.onPageScroll || !!this.props.onPageSelected || !!this.props.onPageScrollStateChanged
-        let needMonitorTouch = !!this.props.onPageScrollStateChanged
-        let props = {
+_renderOnIOS () {
+    let childrenCount = this.props.children ? this.props.children.length : 0
+    let initialPage = Math.min(Math.max(0, this.props.initialPage), childrenCount - 1)
+    let needMonitorScroll = !!this.props.onPageScroll || !!this.props.onPageSelected || !!this.props.onPageScrollStateChanged
+    let needMonitorTouch = !!this.props.onPageScrollStateChanged
+    let props = {
             ...this.props,
-            ref: SCROLLVIEW_REF,
-            onLayout: this._onScrollViewLayout,
-            horizontal: true,
-            pagingEnabled: this.props.horizontalScroll ? true : false,
-            scrollsToTop: false,
-            showsHorizontalScrollIndicator: false,
-            showsVerticalScrollIndicator: false,
-            children: this._childrenWithOverridenStyle(),
-            contentOffset: {x: this.state.width * initialPage, y: 0},
-            decelerationRate: 0.9,
-            onScroll: needMonitorScroll ? this._onScrollOnIOS : null,
-            scrollEventThrottle: needMonitorScroll ? ( this.props.onPageScroll ? 8 : 1) : 0
-        }
-        if (needMonitorTouch) props = Object.assign(props, this._panResponder.panHandlers)
-        const scrollViewStyle = {
-            overflow: 'visible',
-            marginHorizontal: -this.props.pageMargin / 2
-        }
-        if (this.props.style && !this.props.style.height)
-            return <ScrollView {...props} style={[scrollViewStyle, this.props.style]} />
-        else return (
-            <View style={this.props.style} >
-                <ScrollView {...props} style={scrollViewStyle} />
-            </View>
-        )
+        ref: SCROLLVIEW_REF,
+        onLayout: this._onScrollViewLayout,
+        horizontal: true,
+        pagingEnabled: this.props.horizontalScroll ? true : false,
+        scrollEnabled: this.props.horizontalScroll ? true : false,
+        scrollsToTop: false,
+        showsHorizontalScrollIndicator: false,
+        showsVerticalScrollIndicator: false,
+        children: this._childrenWithOverridenStyle(),
+        contentOffset: {x: this.state.width * initialPage, y: 0},
+    decelerationRate: 0.9,
+        onScroll: needMonitorScroll ? this._onScrollOnIOS : null,
+        scrollEventThrottle: needMonitorScroll ? ( this.props.onPageScroll ? 8 : 1) : 0
+}
+    if (needMonitorTouch) props = Object.assign(props, this._panResponder.panHandlers)
+    const scrollViewStyle = {
+        overflow: 'visible',
+        marginHorizontal: -this.props.pageMargin / 2
     }
+    if (this.props.style && !this.props.style.height)
+        return <ScrollView {...props} style={[scrollViewStyle, this.props.style]} />
+else return (
+        <View style={this.props.style} >
+<ScrollView {...props} style={scrollViewStyle} />
+    </View>
+)
+}
 
-    _onScrollOnIOS (e) {
-        let {x} = e.nativeEvent.contentOffset, offset, position = Math.floor(x / this.state.width)
-        if (x === this._preScrollX) return
-        this._preScrollX = x
-        offset = x / this.state.width - position
+_onScrollOnIOS (e) {
+    let {x} = e.nativeEvent.contentOffset, offset, position = Math.floor(x / this.state.width)
+    if (x === this._preScrollX) return
+    this._preScrollX = x
+    offset = x / this.state.width - position
 
-        if (this.props.onPageScroll) this.props.onPageScroll({offset, position})
+    if (this.props.onPageScroll) this.props.onPageScroll({offset, position})
 
-        if (this.props.onPageSelected && offset === 0) {
-            this.props.onPageSelected({position})
-            this.props.onPageScrollStateChanged && this._setScrollState(SCROLL_STATE.idle)
-            this.setState({page: position})
-        }
+    if (this.props.onPageSelected && offset === 0) {
+        this.props.onPageSelected({position})
+        this.props.onPageScrollStateChanged && this._setScrollState(SCROLL_STATE.idle)
     }
+}
 
-    _onScrollViewLayout (event) {
-        let {width, height} = event.nativeEvent.layout
-        this.setState({width, height}, () => Platform.OS === 'ios' && this.setPageWithoutAnimation(this.state.page))
-    }
+_onScrollViewLayout (event) {
+    let {width, height} = event.nativeEvent.layout
+    this.setState({width, height})
+}
 
-    _childrenWithOverridenStyle () {
-        if (this.state.width === 0 || this.state.height === 0) return null
-        return React.Children.map(this.props.children, (child) => {
-            if (!child)return null
-            let newProps = {
-                ...child.props,
-                style: [child.props.style, {
-                    width: this.state.width,
-                    height: this.state.height,
-                    position: null
-                }],
-                collapsable: false
-            }
-            if (child.type &&
-                child.type.displayName &&
-                (child.type.displayName !== 'RCTView') &&
-                (child.type.displayName !== 'View')) {
-                console.warn('Each ViewPager child must be a <View>. Was ' + child.type.displayName)
-            }
-            return React.createElement(child.type, newProps)
-        })
+_childrenWithOverridenStyle () {
+    if (this.state.width === 0 || this.state.height === 0) return null
+    return React.Children.map(this.props.children, (child) => {
+        if (!child)return null
+    let newProps = {
+            ...child.props,
+        style: [child.props.style, {
+        width: this.state.width,
+        height: this.state.height,
+        position: null
+    }],
+        collapsable: false
+}
+    if (child.type &&
+        child.type.displayName &&
+        (child.type.displayName !== 'RCTView') &&
+        (child.type.displayName !== 'View')) {
+        console.warn('Each ViewPager child must be a <View>. Was ' + child.type.displayName)
     }
+    return React.createElement(child.type, newProps)
+})
+}
 
-    _setScrollState (scrollState) {
-        if (scrollState === this._scrollState) return
-        this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(scrollState)
-        this._scrollState = scrollState
-    }
+_setScrollState (scrollState) {
+    if (scrollState === this._scrollState) return
+    this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(scrollState)
+    this._scrollState = scrollState
+}
 
-    setPageWithoutAnimation (selectedPage) {
-        this.setState({page: selectedPage})
-        if (this.props.forceScrollView || Platform.OS === 'ios')
-            this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage, animated: false})
-        else {
-            this.refs[VIEWPAGER_REF].setPageWithoutAnimation(selectedPage)
-            if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
-        }
+setPageWithoutAnimation (selectedPage) {
+    if (this.props.forceScrollView || Platform.OS === 'ios')
+        this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage, animated: false})
+    else {
+        this.refs[VIEWPAGER_REF].setPageWithoutAnimation(selectedPage)
+        if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
     }
+}
 
-    setPage (selectedPage) {
-        this.setState({page: selectedPage})
-        if (this.props.forceScrollView || Platform.OS === 'ios') this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage})
-        else {
-            this.refs[VIEWPAGER_REF].setPage(selectedPage)
-            if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
-        }
+setPage (selectedPage) {
+    if (this.props.forceScrollView || Platform.OS === 'ios') this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage})
+    else {
+        this.refs[VIEWPAGER_REF].setPage(selectedPage)
+        if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
     }
+}
 
 }

--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -18,164 +18,167 @@ const SCROLL_STATE = {
 export default class ViewPager extends Component {
     static propTypes = {...ViewPagerAndroid.propTypes}
 
-static defaultProps = {
-    initialPage: 0,
-    keyboardDismissMode: 'on-drag',
-    onPageScroll: null,
-    onPageSelected: null,
-    onPageScrollStateChanged: null,
-    pageMargin: 0,
-    horizontalScroll: true
-}
+    static defaultProps = {
+        initialPage: 0,
+        keyboardDismissMode: 'on-drag',
+        onPageScroll: null,
+        onPageSelected: null,
+        onPageScrollStateChanged: null,
+        pageMargin: 0,
+        horizontalScroll: true
+    }
 
-state = {width: 0, height: 0}
 
-_scrollState = SCROLL_STATE.idle
+    _scrollState = SCROLL_STATE.idle
 
-_preScrollX = null
+    _preScrollX = null
 
-_panResponder = PanResponder.create({
-    onStartShouldSetPanResponder: () => true,
-    onMoveShouldSetPanResponder: () => true,
-    onPanResponderGrant: () => this._setScrollState(SCROLL_STATE.dragging),
-    onPanResponderMove: () => null,
-    onPanResponderRelease: () => this._setScrollState(SCROLL_STATE.settling),
-    onPanResponderTerminate: () => null,
-    onPanResponderTerminationRequest: (evt, gestureState) => true
-})
+    _panResponder = PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderGrant: () => this._setScrollState(SCROLL_STATE.dragging),
+        onPanResponderMove: () => null,
+        onPanResponderRelease: () => this._setScrollState(SCROLL_STATE.settling),
+        onPanResponderTerminate: () => null,
+        onPanResponderTerminationRequest: (evt, gestureState) => true
+    })
 
-constructor (props) {
-    super(props)
-    this._onPageScrollOnAndroid = this._onPageScrollOnAndroid.bind(this)
-    this._onPageSelectedOnAndroid = this._onPageSelectedOnAndroid.bind(this)
-    this._renderOnIOS = this._renderOnIOS.bind(this)
-    this._onScrollOnIOS = this._onScrollOnIOS.bind(this)
-    this._onScrollViewLayout = this._onScrollViewLayout.bind(this)
-    this._childrenWithOverridenStyle = this._childrenWithOverridenStyle.bind(this)
-    this._setScrollState = this._setScrollState.bind(this)
-    this.setPageWithoutAnimation = this.setPageWithoutAnimation.bind(this)
-    this.setPage = this.setPage.bind(this)
-}
+    constructor (props) {
+        super(props)
+        this._onPageScrollOnAndroid = this._onPageScrollOnAndroid.bind(this)
+        this._onPageSelectedOnAndroid = this._onPageSelectedOnAndroid.bind(this)
+        this._renderOnIOS = this._renderOnIOS.bind(this)
+        this._onScrollOnIOS = this._onScrollOnIOS.bind(this)
+        this._onScrollViewLayout = this._onScrollViewLayout.bind(this)
+        this._childrenWithOverridenStyle = this._childrenWithOverridenStyle.bind(this)
+        this._setScrollState = this._setScrollState.bind(this)
+        this.setPageWithoutAnimation = this.setPageWithoutAnimation.bind(this)
+        this.setPage = this.setPage.bind(this)
+        this.state = {width: 0, height: 0, page: props.initialPage}
+    }
 
-render () {
-    return (this.props.forceScrollView || Platform.OS === 'ios') ? this._renderOnIOS() : (
-        <ViewPagerAndroid
-    {...this.props}
-    scrollEnabled={this.props.horizontalScroll ? true : false}
-    ref={VIEWPAGER_REF}
-    key={this.props.children ? this.props.children.length : 0}
-    onPageScroll={this._onPageScrollOnAndroid}
-    onPageSelected={this._onPageSelectedOnAndroid}
-    />
-)
-}
+    render () {
+        return (this.props.forceScrollView || Platform.OS === 'ios') ? this._renderOnIOS() : (
+            <ViewPagerAndroid
+                {...this.props}
+                scrollEnabled={this.props.horizontalScroll ? true : false}
+                ref={VIEWPAGER_REF}
+                key={this.props.children ? this.props.children.length : 0}
+                onPageScroll={this._onPageScrollOnAndroid}
+                onPageSelected={this._onPageSelectedOnAndroid}
+            />
+        )
+    }
 
-_onPageScrollOnAndroid (e) {
-    if (this.props.onPageScroll) this.props.onPageScroll(e.nativeEvent)
-}
+    _onPageScrollOnAndroid (e) {
+        if (this.props.onPageScroll) this.props.onPageScroll(e.nativeEvent)
+    }
 
-_onPageSelectedOnAndroid (e) {
-    if (this.props.onPageSelected) this.props.onPageSelected(e.nativeEvent)
-}
+    _onPageSelectedOnAndroid (e) {
+        if (this.props.onPageSelected) this.props.onPageSelected(e.nativeEvent)
+    }
 
-_renderOnIOS () {
-    let childrenCount = this.props.children ? this.props.children.length : 0
-    let initialPage = Math.min(Math.max(0, this.props.initialPage), childrenCount - 1)
-    let needMonitorScroll = !!this.props.onPageScroll || !!this.props.onPageSelected || !!this.props.onPageScrollStateChanged
-    let needMonitorTouch = !!this.props.onPageScrollStateChanged
-    let props = {
+    _renderOnIOS () {
+        let childrenCount = this.props.children ? this.props.children.length : 0
+        let initialPage = Math.min(Math.max(0, this.props.initialPage), childrenCount - 1)
+        let needMonitorScroll = !!this.props.onPageScroll || !!this.props.onPageSelected || !!this.props.onPageScrollStateChanged
+        let needMonitorTouch = !!this.props.onPageScrollStateChanged
+        let props = {
             ...this.props,
-        ref: SCROLLVIEW_REF,
-        onLayout: this._onScrollViewLayout,
-        horizontal: true,
-        pagingEnabled: this.props.horizontalScroll ? true : false,
-        scrollEnabled: this.props.horizontalScroll ? true : false,
-        scrollsToTop: false,
-        showsHorizontalScrollIndicator: false,
-        showsVerticalScrollIndicator: false,
-        children: this._childrenWithOverridenStyle(),
-        contentOffset: {x: this.state.width * initialPage, y: 0},
-    decelerationRate: 0.9,
-        onScroll: needMonitorScroll ? this._onScrollOnIOS : null,
-        scrollEventThrottle: needMonitorScroll ? ( this.props.onPageScroll ? 8 : 1) : 0
-}
-    if (needMonitorTouch) props = Object.assign(props, this._panResponder.panHandlers)
-    const scrollViewStyle = {
-        overflow: 'visible',
-        marginHorizontal: -this.props.pageMargin / 2
+            ref: SCROLLVIEW_REF,
+            onLayout: this._onScrollViewLayout,
+            horizontal: true,
+            pagingEnabled: this.props.horizontalScroll ? true : false,
+            scrollEnabled: this.props.horizontalScroll ? true : false,
+            scrollsToTop: false,
+            showsHorizontalScrollIndicator: false,
+            showsVerticalScrollIndicator: false,
+            children: this._childrenWithOverridenStyle(),
+            contentOffset: {x: this.state.width * initialPage, y: 0},
+            decelerationRate: 0.9,
+            onScroll: needMonitorScroll ? this._onScrollOnIOS : null,
+            scrollEventThrottle: needMonitorScroll ? ( this.props.onPageScroll ? 8 : 1) : 0
+        }
+        if (needMonitorTouch) props = Object.assign(props, this._panResponder.panHandlers)
+        const scrollViewStyle = {
+            overflow: 'visible',
+            marginHorizontal: -this.props.pageMargin / 2
+        }
+        if (this.props.style && !this.props.style.height)
+            return <ScrollView {...props} style={[scrollViewStyle, this.props.style]} />
+        else return (
+            <View style={this.props.style} >
+                <ScrollView {...props} style={scrollViewStyle} />
+            </View>
+        )
     }
-    if (this.props.style && !this.props.style.height)
-        return <ScrollView {...props} style={[scrollViewStyle, this.props.style]} />
-else return (
-        <View style={this.props.style} >
-<ScrollView {...props} style={scrollViewStyle} />
-    </View>
-)
-}
 
-_onScrollOnIOS (e) {
-    let {x} = e.nativeEvent.contentOffset, offset, position = Math.floor(x / this.state.width)
-    if (x === this._preScrollX) return
-    this._preScrollX = x
-    offset = x / this.state.width - position
+    _onScrollOnIOS (e) {
+        let {x} = e.nativeEvent.contentOffset, offset, position = Math.floor(x / this.state.width)
+        if (x === this._preScrollX) return
+        this._preScrollX = x
+        offset = x / this.state.width - position
 
-    if (this.props.onPageScroll) this.props.onPageScroll({offset, position})
+        if (this.props.onPageScroll) this.props.onPageScroll({offset, position})
 
-    if (this.props.onPageSelected && offset === 0) {
-        this.props.onPageSelected({position})
-        this.props.onPageScrollStateChanged && this._setScrollState(SCROLL_STATE.idle)
+        if (this.props.onPageSelected && offset === 0) {
+            this.props.onPageSelected({position})
+            this.props.onPageScrollStateChanged && this._setScrollState(SCROLL_STATE.idle)
+            this.setState({page: position})
+        }
     }
-}
 
-_onScrollViewLayout (event) {
-    let {width, height} = event.nativeEvent.layout
-    this.setState({width, height})
-}
-
-_childrenWithOverridenStyle () {
-    if (this.state.width === 0 || this.state.height === 0) return null
-    return React.Children.map(this.props.children, (child) => {
-        if (!child)return null
-    let newProps = {
-            ...child.props,
-        style: [child.props.style, {
-        width: this.state.width,
-        height: this.state.height,
-        position: null
-    }],
-        collapsable: false
-}
-    if (child.type &&
-        child.type.displayName &&
-        (child.type.displayName !== 'RCTView') &&
-        (child.type.displayName !== 'View')) {
-        console.warn('Each ViewPager child must be a <View>. Was ' + child.type.displayName)
+    _onScrollViewLayout (event) {
+        let {width, height} = event.nativeEvent.layout
+        this.setState({width, height}, () => Platform.OS === 'ios' && this.setPageWithoutAnimation(this.state.page))
     }
-    return React.createElement(child.type, newProps)
-})
-}
 
-_setScrollState (scrollState) {
-    if (scrollState === this._scrollState) return
-    this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(scrollState)
-    this._scrollState = scrollState
-}
-
-setPageWithoutAnimation (selectedPage) {
-    if (this.props.forceScrollView || Platform.OS === 'ios')
-        this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage, animated: false})
-    else {
-        this.refs[VIEWPAGER_REF].setPageWithoutAnimation(selectedPage)
-        if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
+    _childrenWithOverridenStyle () {
+        if (this.state.width === 0 || this.state.height === 0) return null
+        return React.Children.map(this.props.children, (child) => {
+            if (!child)return null
+            let newProps = {
+                ...child.props,
+                style: [child.props.style, {
+                    width: this.state.width,
+                    height: this.state.height,
+                    position: null
+                }],
+                collapsable: false
+            }
+            if (child.type &&
+                child.type.displayName &&
+                (child.type.displayName !== 'RCTView') &&
+                (child.type.displayName !== 'View')) {
+                console.warn('Each ViewPager child must be a <View>. Was ' + child.type.displayName)
+            }
+            return React.createElement(child.type, newProps)
+        })
     }
-}
 
-setPage (selectedPage) {
-    if (this.props.forceScrollView || Platform.OS === 'ios') this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage})
-    else {
-        this.refs[VIEWPAGER_REF].setPage(selectedPage)
-        if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
+    _setScrollState (scrollState) {
+        if (scrollState === this._scrollState) return
+        this.props.onPageScrollStateChanged && this.props.onPageScrollStateChanged(scrollState)
+        this._scrollState = scrollState
     }
-}
+
+    setPageWithoutAnimation (selectedPage) {
+        this.setState({page: selectedPage})
+        if (this.props.forceScrollView || Platform.OS === 'ios')
+            this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage, animated: false})
+        else {
+            this.refs[VIEWPAGER_REF].setPageWithoutAnimation(selectedPage)
+            if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
+        }
+    }
+
+    setPage (selectedPage) {
+        this.setState({page: selectedPage})
+        if (this.props.forceScrollView || Platform.OS === 'ios') this.refs[SCROLLVIEW_REF].scrollTo({x: this.state.width * selectedPage})
+        else {
+            this.refs[VIEWPAGER_REF].setPage(selectedPage)
+            if (this.props.onPageSelected) this.props.onPageSelected({position: selectedPage})
+        }
+    }
 
 }


### PR DESCRIPTION
@zbtang  你好，项目中用到了你贡献的项目，给了我很大的帮助，非常感谢！
但是在使用过程中，我发现ViewPager禁用滚动的属性设置无效，翻了源码，发现了问题所在

1. ViewPager.md中显示禁用滚动的属性是scrollEnabled，默认值是false
![image](https://user-images.githubusercontent.com/13824924/34562060-b0fb01ae-f187-11e7-82ce-c557c7ba2efd.png)
但是在源码中用于控制滚动的属性却是horizontalScroll，默认值是true
2.  ViewPager中针对iOS端的实现是用的ScrollView，但是并未设置ScrollView的scrollEnabled属性，所以iOS加了`horizontalScroll={false}`也无效

**针对上述问题，我做了两处修改**
1. 修改了ViewPager.md
由：`| scrollEnabled | bool | false |  |`
改为：`| horizontalScroll | bool | true |  |`
2. 在ViewPager.js的[92行](https://github.com/shixiaoquan/React-Native-ViewPager/blob/c916de74f5fece0d82b007c3512bcc9f96651f55/viewpager/ViewPager.js#L92)，添加了`scrollEnabled: this.props.horizontalScroll ? true : false,`