### PR TITLE
Fix IndicatorViewPagerProps type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module 'rn-viewpager' {
       setPageWithoutAnimation(selectedPage: number): void;
     }
 
-    interface IndicatorViewPagerProps extends ViewProperties {
+    interface IndicatorViewPagerProps extends ViewPagerProps {
       indicator: React.ReactNode;
       pagerStyle?: ViewProperties['style'];
       autoPlayEnable?: boolean;


### PR DESCRIPTION
`IndicatorViewPagerProps` type should extend `ViewPagerProps`. https://github.com/zbtang/React-Native-ViewPager/blob/38a78ae/viewpager/IndicatorViewPager.js#L16

This PR also fixes https://github.com/zbtang/React-Native-ViewPager/pull/115 .