### PR TITLE
Fix: ScrollView content flowing out of screen on iOS

### DIFF
--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -101,7 +101,7 @@ export default class ViewPager extends Component {
         }
         if (needMonitorTouch) props = Object.assign(props, this._panResponder.panHandlers)
         const scrollViewStyle = {
-            overflow: 'visible',
+            overflow: 'hidden',
             marginHorizontal: -this.props.pageMargin / 2
         }
         if (this.props.style && !this.props.style.height)


### PR DESCRIPTION
Fix scrollview content view flowing out of screen on iOS visible during stack navigation back.