### PR TITLE
Made IndicatorViewPagerProps extend ViewPagerProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module 'rn-viewpager' {
       setPageWithoutAnimation(selectedPage: number): void;
     }
 
-    interface IndicatorViewPagerProps extends ViewProperties {
+    interface IndicatorViewPagerProps extends ViewPagerProps {
       indicator: React.ReactNode;
       pagerStyle?: ViewProperties['style'];
       autoPlayEnable?: boolean;


### PR DESCRIPTION
In my last types definition I forgot to extend the `IndicatorViewPagerProps` from `ViewPagerProps`