### PR TITLE
remove border from tab container

### DIFF
--- a/docs/tabindicator.md
+++ b/docs/tabindicator.md
@@ -3,6 +3,7 @@
 
 | Prop | Type | Default | Note |
 | --- | --- | --- | --- |
+| style | ViewPropTypes.style | --- | --- |
 | tabs | PropTypes.arrayOf(PropTypes.shape({text: PropTypes.string,iconSource: Image.propTypes.source,selectedIconSource: Image.propTypes.source})) |  |  |
 | itemStyle | ViewPropTypes.style |  |  |
 | selectedItemStyle | ViewPropTypes.style |  |  |

--- a/docs/tabindicator.md
+++ b/docs/tabindicator.md
@@ -3,7 +3,7 @@
 
 | Prop | Type | Default | Note |
 | --- | --- | --- | --- |
-| style | ViewPropTypes.style | --- | --- |
+| style | ViewPropTypes.style | | |
 | tabs | PropTypes.arrayOf(PropTypes.shape({text: PropTypes.string,iconSource: Image.propTypes.source,selectedIconSource: Image.propTypes.source})) |  |  |
 | itemStyle | ViewPropTypes.style |  |  |
 | selectedItemStyle | ViewPropTypes.style |  |  |

--- a/viewpager/indicator/PagerTabIndicator.js
+++ b/viewpager/indicator/PagerTabIndicator.js
@@ -87,8 +87,6 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         paddingTop: 8,
         paddingBottom: 4,
-        borderTopWidth: 0.5,
-        borderTopColor: '#E0E0E0',
         backgroundColor: '#F7F7F7'
     },
     itemContainer: {


### PR DESCRIPTION
Using the style prop, this border can be implemented as needed.
Implementing on a use-case basis would seem to be a better practice than disabling these borders for every use. 

Updated docs to reflect this change