### PR TITLE
Fix PagerDotIndicator Container Taking Up Entire Width of View on iOS

### DIFF
--- a/viewpager/indicator/PagerDotIndicator.js
+++ b/viewpager/indicator/PagerDotIndicator.js
@@ -66,6 +66,7 @@ export default class PagerDotIndicator extends Component {
 const styles = StyleSheet.create({
     container: {
         alignSelf: 'center',
+        position: 'absolute',
         bottom: 10,
         flexDirection: 'row',
         alignItems: 'center',

--- a/viewpager/indicator/PagerDotIndicator.js
+++ b/viewpager/indicator/PagerDotIndicator.js
@@ -65,10 +65,8 @@ export default class PagerDotIndicator extends Component {
 }
 const styles = StyleSheet.create({
     container: {
-        position: 'absolute',
+        alignSelf: 'center',
         bottom: 10,
-        left: 0,
-        right: 0,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center'


### PR DESCRIPTION
This fixes an issue on iOS where the container holding the dots takes up the entire width to the left and right of the dots. Before this fix, the container would block any elements that are rendered to the left and right of the dots. After this fix, the container shrinks down to only occupy the space that the dots occupy.

Here's some images showing the issue using the React Native Inspector:

# Before

![image](https://user-images.githubusercontent.com/7661552/58516240-2b9a0800-815c-11e9-99dc-ba9ef5cfefb1.png)

# After

![image](https://user-images.githubusercontent.com/7661552/58516251-318fe900-815c-11e9-938e-902a2ec97ae8.png)