### PR TITLE
Add page scroll and page selected events to IndicatorViewPagerProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,8 +23,10 @@ declare module 'rn-viewpager' {
       autoPlayEnable?: boolean;
       autoPlayInterval?: boolean;
       horizontalScroll?: boolean;
-
+      onPageScroll?(e: ViewPagerAndroidOnPageScrollEventData): void;
+      onPageSelected?(e: ViewPagerAndroidOnPageScrollEventData): void;
     }
+
     export class IndicatorViewPager extends React.Component<IndicatorViewPagerProps> {
       setPage(selectedPage: number): void;
       setPageWithoutAnimation(selectedPage: number): void;


### PR DESCRIPTION
This is so the IndicatorViewPager can use those events, too. Both events are properly passed from the ViewPager to the IndicatorViewPager, already. This can be seen here:

- https://github.com/zbtang/React-Native-ViewPager/blob/master/viewpager/IndicatorViewPager.js#L66
- https://github.com/zbtang/React-Native-ViewPager/blob/master/viewpager/IndicatorViewPager.js#L81
- https://github.com/zbtang/React-Native-ViewPager/blob/master/viewpager/IndicatorViewPager.js#L87

This fixes #173