### PR TITLE
Fix ViewPagerAndroid extracted from react-native core. Add @react-native-community/viewpager as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "rn-viewpager",
+  "version": "1.2.9",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@react-native-community/viewpager": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/viewpager/-/viewpager-1.1.7.tgz",
+      "integrity": "sha512-k9v2KJtAprNPq7IZmedD2VLMePvPW+ohX3uDnkpoKritBji+/RtRmTKrdtPi3Uvp0toq/KtPttAds1dr7AZNpw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/zbtang/React-Native-ViewPager.git"
   },
+  "dependencies": {
+    "@react-native-community/viewpager": "^1.1.7"
+  },
   "keywords": [
     "react-native-component",
     "react-component",

--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -4,7 +4,8 @@
 
 'use strict'
 
-import { PanResponder, Platform, ScrollView, StyleSheet, View, ViewPagerAndroid } from 'react-native'
+import { PanResponder, Platform, ScrollView, StyleSheet, View } from 'react-native'
+import ViewPagerAndroid from "@react-native-community/viewpager";
 import React, { Component } from 'react'
 
 const SCROLLVIEW_REF = 'scrollView'


### PR DESCRIPTION
Fixes breaking issue - for ViewPagerAndroid extracted from React Native 0.61. https://github.com/zbtang/React-Native-ViewPager/issues/168